### PR TITLE
Check for tables and create if needed

### DIFF
--- a/internal/clients/bigquery/bigquery.go
+++ b/internal/clients/bigquery/bigquery.go
@@ -11,7 +11,11 @@ import (
 
 type BigQueryClient interface {
 	GetMostRecentBlockNumber(ctx context.Context) (int64, error)
+	CreateBlocksTable(ctx context.Context) error
+	BlocksTableExists(ctx context.Context) bool
 	InsertBlock(block *model.Block, ctx context.Context) error
+	CreateTransactionsTable(ctx context.Context) error
+	TransactionsTableExists(ctx context.Context) bool
 	InsertTransactions(transactions []*model.Transaction, ctx context.Context) error
 	io.Closer
 }

--- a/internal/clients/bigquery/mock_bigquery/mock.go
+++ b/internal/clients/bigquery/mock_bigquery/mock.go
@@ -35,6 +35,20 @@ func (m *MockBigQueryClient) EXPECT() *MockBigQueryClientMockRecorder {
 	return m.recorder
 }
 
+// BlocksTableExists mocks base method.
+func (m *MockBigQueryClient) BlocksTableExists(ctx context.Context) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "BlocksTableExists", ctx)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// BlocksTableExists indicates an expected call of BlocksTableExists.
+func (mr *MockBigQueryClientMockRecorder) BlocksTableExists(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "BlocksTableExists", reflect.TypeOf((*MockBigQueryClient)(nil).BlocksTableExists), ctx)
+}
+
 // Close mocks base method.
 func (m *MockBigQueryClient) Close() error {
 	m.ctrl.T.Helper()
@@ -47,6 +61,34 @@ func (m *MockBigQueryClient) Close() error {
 func (mr *MockBigQueryClientMockRecorder) Close() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockBigQueryClient)(nil).Close))
+}
+
+// CreateBlocksTable mocks base method.
+func (m *MockBigQueryClient) CreateBlocksTable(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateBlocksTable", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateBlocksTable indicates an expected call of CreateBlocksTable.
+func (mr *MockBigQueryClientMockRecorder) CreateBlocksTable(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateBlocksTable", reflect.TypeOf((*MockBigQueryClient)(nil).CreateBlocksTable), ctx)
+}
+
+// CreateTransactionsTable mocks base method.
+func (m *MockBigQueryClient) CreateTransactionsTable(ctx context.Context) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateTransactionsTable", ctx)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// CreateTransactionsTable indicates an expected call of CreateTransactionsTable.
+func (mr *MockBigQueryClientMockRecorder) CreateTransactionsTable(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransactionsTable", reflect.TypeOf((*MockBigQueryClient)(nil).CreateTransactionsTable), ctx)
 }
 
 // GetMostRecentBlockNumber mocks base method.
@@ -90,4 +132,18 @@ func (m *MockBigQueryClient) InsertTransactions(transactions []*model.Transactio
 func (mr *MockBigQueryClientMockRecorder) InsertTransactions(transactions, ctx interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertTransactions", reflect.TypeOf((*MockBigQueryClient)(nil).InsertTransactions), transactions, ctx)
+}
+
+// TransactionsTableExists mocks base method.
+func (m *MockBigQueryClient) TransactionsTableExists(ctx context.Context) bool {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "TransactionsTableExists", ctx)
+	ret0, _ := ret[0].(bool)
+	return ret0
+}
+
+// TransactionsTableExists indicates an expected call of TransactionsTableExists.
+func (mr *MockBigQueryClientMockRecorder) TransactionsTableExists(ctx interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "TransactionsTableExists", reflect.TypeOf((*MockBigQueryClient)(nil).TransactionsTableExists), ctx)
 }

--- a/internal/model/block.go
+++ b/internal/model/block.go
@@ -26,12 +26,12 @@ type Block struct {
 
 func (block *Block) Save() (map[string]bigquery.Value, string, error) {
 	return map[string]bigquery.Value{
+		"blockHash":        block.Hash,
 		"difficulty":       block.Difficulty,
 		"epoch":            block.Epoch,
 		"extraData":        block.ExtraData,
 		"gasLimit":         block.GasLimit,
 		"gasUsed":          block.GasUsed,
-		"hash":             block.Hash,
 		"logBloom":         block.LogBloom,
 		"miner":            block.Miner,
 		"mixHash":          block.MixHash,

--- a/internal/model/transaction.go
+++ b/internal/model/transaction.go
@@ -31,7 +31,6 @@ func (txn *Transaction) Save() (map[string]bigquery.Value, string, error) {
 		"from":             txn.From,
 		"gas":              txn.Gas,
 		"gasPrice":         txn.GasPrice,
-		"hash":             txn.Hash,
 		"input":            txn.Input,
 		"nonce":            txn.Nonce,
 		"r":                txn.R,
@@ -41,6 +40,7 @@ func (txn *Transaction) Save() (map[string]bigquery.Value, string, error) {
 		"to":               txn.To,
 		"toShardID":        txn.ToShardID,
 		"transactionIndex": txn.TransactionIndex,
+		"txnHash":          txn.Hash,
 		"v":                txn.V,
 		"value":            txn.Value,
 	}, bigquery.NoDedupeID, nil

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -1,0 +1,48 @@
+package schema
+
+import (
+	"cloud.google.com/go/bigquery"
+)
+
+var (
+	BlocksTableSchema = bigquery.Schema{
+		{Name: "blockHash", Type: bigquery.StringFieldType},
+		{Name: "difficulty", Type: bigquery.StringFieldType},
+		{Name: "epoch", Type: bigquery.StringFieldType},
+		{Name: "extraData", Type: bigquery.StringFieldType},
+		{Name: "gasLimit", Type: bigquery.StringFieldType},
+		{Name: "gasUsed", Type: bigquery.StringFieldType},
+		{Name: "logBloom", Type: bigquery.StringFieldType},
+		{Name: "miner", Type: bigquery.StringFieldType},
+		{Name: "mixHash", Type: bigquery.StringFieldType},
+		{Name: "nonce", Type: bigquery.IntegerFieldType},
+		{Name: "number", Type: bigquery.StringFieldType},
+		{Name: "parentHash", Type: bigquery.StringFieldType},
+		{Name: "receiptsRoot", Type: bigquery.StringFieldType},
+		{Name: "size", Type: bigquery.StringFieldType},
+		{Name: "stateRoot", Type: bigquery.StringFieldType},
+		{Name: "timestamp", Type: bigquery.StringFieldType},
+		{Name: "transactionsRoot", Type: bigquery.StringFieldType},
+		{Name: "viewID", Type: bigquery.StringFieldType},
+	}
+	TransactionsTableSchema = bigquery.Schema{
+		{Name: "blockHash", Type: bigquery.StringFieldType},
+		{Name: "blockNumber", Type: bigquery.StringFieldType},
+		{Name: "ethHash", Type: bigquery.StringFieldType},
+		{Name: "from", Type: bigquery.StringFieldType},
+		{Name: "gas", Type: bigquery.StringFieldType},
+		{Name: "gasPrice", Type: bigquery.StringFieldType},
+		{Name: "input", Type: bigquery.StringFieldType},
+		{Name: "nonce", Type: bigquery.StringFieldType},
+		{Name: "r", Type: bigquery.StringFieldType},
+		{Name: "s", Type: bigquery.StringFieldType},
+		{Name: "shardID", Type: bigquery.IntegerFieldType},
+		{Name: "timestamp", Type: bigquery.StringFieldType},
+		{Name: "to", Type: bigquery.StringFieldType},
+		{Name: "toShardID", Type: bigquery.IntegerFieldType},
+		{Name: "transactionIndex", Type: bigquery.StringFieldType},
+		{Name: "txnHash", Type: bigquery.StringFieldType},
+		{Name: "v", Type: bigquery.StringFieldType},
+		{Name: "value", Type: bigquery.StringFieldType},
+	}
+)


### PR DESCRIPTION
Resolves #5 by adding functionality to the BigQuery client to check for table existence and to create blocks and txns tables. This also includes an update to the runner to perform the table checks and create if needed. 