### PR TITLE
Deduplicate bigquery records

### DIFF
--- a/internal/clients/bigquery/bigquery.go
+++ b/internal/clients/bigquery/bigquery.go
@@ -22,5 +22,7 @@ type BigQueryClient interface {
 	InsertTransactions(transactions []*model.Transaction, ctx context.Context) error
 	GetBlocksSchema(ctx context.Context) (bigquery.Schema, error)
 	GetTransactionSchema(ctx context.Context) (bigquery.Schema, error)
+	GetBlock(ctx context.Context, blockNumber int64) (*model.Block, error)
+	GetTransactions(ctx context.Context, blockNumber int64) ([]*model.Transaction, error)
 	io.Closer
 }

--- a/internal/clients/bigquery/bigquery.go
+++ b/internal/clients/bigquery/bigquery.go
@@ -15,11 +15,11 @@ type BigQueryClient interface {
 	ProjectDatasetExists(ctx context.Context) bool
 	CreateBlocksTable(ctx context.Context) error
 	BlocksTableExists(ctx context.Context) bool
-	InsertBlock(block *model.Block, ctx context.Context) error
+	InsertBlock(ctx context.Context, block *model.Block) error
 	CreateProjectDataset(ctx context.Context) error
 	CreateTransactionsTable(ctx context.Context) error
 	TransactionsTableExists(ctx context.Context) bool
-	InsertTransactions(transactions []*model.Transaction, ctx context.Context) error
+	InsertTransactions(ctx context.Context, transactions []*model.Transaction) error
 	GetBlocksSchema(ctx context.Context) (bigquery.Schema, error)
 	GetTransactionSchema(ctx context.Context) (bigquery.Schema, error)
 	GetBlock(ctx context.Context, blockNumber int64) (*model.Block, error)

--- a/internal/clients/bigquery/mock_bigquery/mock.go
+++ b/internal/clients/bigquery/mock_bigquery/mock.go
@@ -106,6 +106,21 @@ func (mr *MockBigQueryClientMockRecorder) CreateTransactionsTable(ctx interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateTransactionsTable", reflect.TypeOf((*MockBigQueryClient)(nil).CreateTransactionsTable), ctx)
 }
 
+// GetBlock mocks base method.
+func (m *MockBigQueryClient) GetBlock(ctx context.Context, blockNumber int64) (*model.Block, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetBlock", ctx, blockNumber)
+	ret0, _ := ret[0].(*model.Block)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetBlock indicates an expected call of GetBlock.
+func (mr *MockBigQueryClientMockRecorder) GetBlock(ctx, blockNumber interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlock", reflect.TypeOf((*MockBigQueryClient)(nil).GetBlock), ctx, blockNumber)
+}
+
 // GetBlocksSchema mocks base method.
 func (m *MockBigQueryClient) GetBlocksSchema(ctx context.Context) (bigquery.Schema, error) {
 	m.ctrl.T.Helper()
@@ -151,32 +166,47 @@ func (mr *MockBigQueryClientMockRecorder) GetTransactionSchema(ctx interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransactionSchema", reflect.TypeOf((*MockBigQueryClient)(nil).GetTransactionSchema), ctx)
 }
 
-// InsertBlock mocks base method.
-func (m *MockBigQueryClient) InsertBlock(block *model.Block, ctx context.Context) error {
+// GetTransactions mocks base method.
+func (m *MockBigQueryClient) GetTransactions(ctx context.Context, blockNumber int64) ([]*model.Transaction, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InsertBlock", block, ctx)
+	ret := m.ctrl.Call(m, "GetTransactions", ctx, blockNumber)
+	ret0, _ := ret[0].([]*model.Transaction)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetTransactions indicates an expected call of GetTransactions.
+func (mr *MockBigQueryClientMockRecorder) GetTransactions(ctx, blockNumber interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetTransactions", reflect.TypeOf((*MockBigQueryClient)(nil).GetTransactions), ctx, blockNumber)
+}
+
+// InsertBlock mocks base method.
+func (m *MockBigQueryClient) InsertBlock(ctx context.Context, block *model.Block) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InsertBlock", ctx, block)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InsertBlock indicates an expected call of InsertBlock.
-func (mr *MockBigQueryClientMockRecorder) InsertBlock(block, ctx interface{}) *gomock.Call {
+func (mr *MockBigQueryClientMockRecorder) InsertBlock(ctx, block interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertBlock", reflect.TypeOf((*MockBigQueryClient)(nil).InsertBlock), block, ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertBlock", reflect.TypeOf((*MockBigQueryClient)(nil).InsertBlock), ctx, block)
 }
 
 // InsertTransactions mocks base method.
-func (m *MockBigQueryClient) InsertTransactions(transactions []*model.Transaction, ctx context.Context) error {
+func (m *MockBigQueryClient) InsertTransactions(ctx context.Context, transactions []*model.Transaction) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "InsertTransactions", transactions, ctx)
+	ret := m.ctrl.Call(m, "InsertTransactions", ctx, transactions)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // InsertTransactions indicates an expected call of InsertTransactions.
-func (mr *MockBigQueryClientMockRecorder) InsertTransactions(transactions, ctx interface{}) *gomock.Call {
+func (mr *MockBigQueryClientMockRecorder) InsertTransactions(ctx, transactions interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertTransactions", reflect.TypeOf((*MockBigQueryClient)(nil).InsertTransactions), transactions, ctx)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InsertTransactions", reflect.TypeOf((*MockBigQueryClient)(nil).InsertTransactions), ctx, transactions)
 }
 
 // ProjectDatasetExists mocks base method.

--- a/internal/model/block.go
+++ b/internal/model/block.go
@@ -17,25 +17,25 @@ type RetryBlock struct {
 }
 
 type Block struct {
-	Difficulty       int64          `json:"difficulty"`
-	Epoch            string         `json:"epoch"`
-	ExtraData        string         `json:"extraData"`
-	GasLimit         string         `json:"gasLimit"`
-	GasUsed          string         `json:"gasUsed"`
-	Hash             string         `json:"hash"`
-	LogBloom         string         `json:"logBloom"`
-	Miner            string         `json:"miner"`
-	MixHash          string         `json:"mixHash"`
-	Nonce            int64          `json:"nonce"`
-	Number           string         `json:"number"`
-	ParentHash       string         `json:"parentHash"`
-	ReceiptsRoot     string         `json:"receiptsRoot"`
-	Size             string         `json:"size"`
-	StateRoot        string         `json:"stateRoot"`
-	Timestamp        string         `json:"timestamp"`
-	Transactions     []*Transaction `json:"transactions"`
-	TransactionsRoot string         `json:"transactionsRoot"`
-	ViewID           string         `json:"viewID"`
+	Difficulty       int64          `json:"difficulty" bigquery:"difficulty"`
+	Epoch            string         `json:"epoch" bigquery:"epoch"`
+	ExtraData        string         `json:"extraData" bigquery:"extraData"`
+	GasLimit         string         `json:"gasLimit" bigquery:"gasLimit"`
+	GasUsed          string         `json:"gasUsed" bigquery:"gasUsed"`
+	Hash             string         `json:"hash" bigquery:"hash"`
+	LogBloom         string         `json:"logBloom" bigquery:"logBloom"`
+	Miner            string         `json:"miner" bigquery:"miner"`
+	MixHash          string         `json:"mixHash" bigquery:"mixHash"`
+	Nonce            int64          `json:"nonce" bigquery:"nonce"`
+	Number           string         `json:"number" bigquery:"number"`
+	ParentHash       string         `json:"parentHash" bigquery:"parentHash"`
+	ReceiptsRoot     string         `json:"receiptsRoot" bigquery:"receiptsRoot"`
+	Size             string         `json:"size" bigquery:"size"`
+	StateRoot        string         `json:"stateRoot" bigquery:"stateRoot"`
+	Timestamp        string         `json:"timestamp" bigquery:"timestamp"`
+	Transactions     []*Transaction `json:"transactions" bigquery:"transactions"`
+	TransactionsRoot string         `json:"transactionsRoot" bigquery:"transactionsRoot"`
+	ViewID           string         `json:"viewID" bigquery:"viewID"`
 }
 
 func (block *Block) Save() (map[string]bigquery.Value, string, error) {

--- a/internal/runner/backfill_test.go
+++ b/internal/runner/backfill_test.go
@@ -1,0 +1,161 @@
+package runner
+
+import (
+	"context"
+	"strconv"
+	"sync"
+	"testing"
+
+	"github.com/cpurta/harmony-one-to-bigquery/internal/clients/bigquery/mock_bigquery"
+	"github.com/cpurta/harmony-one-to-bigquery/internal/clients/harmony/mock_harmony"
+	"github.com/cpurta/harmony-one-to-bigquery/internal/model"
+	"github.com/golang/mock/gomock"
+	"go.uber.org/zap"
+)
+
+func TestBackfillBlocks(t *testing.T) {
+	ctrl := gomock.NewController(t)
+
+	defer ctrl.Finish()
+
+	testCases := []struct {
+		name         string
+		currentCount int64
+		endBlock     int64
+		setupMocks   func(*mock_harmony.MockHarmonyClient, *mock_bigquery.MockBigQueryClient)
+	}{
+		{
+			name:         "backfill all",
+			currentCount: 1,
+			endBlock:     10,
+			setupMocks: func(harmonyClient *mock_harmony.MockHarmonyClient, bqClient *mock_bigquery.MockBigQueryClient) {
+				for i := 1; i <= 10; i++ {
+					bqClient.EXPECT().GetBlock(gomock.Any(), int64(i)).Return(nil, nil)
+					bqClient.EXPECT().GetTransactions(gomock.Any(), int64(i)).Return(nil, nil)
+
+					block := &model.Block{
+						Number: strconv.Itoa(i),
+						Transactions: []*model.Transaction{
+							{
+								BlockNumber: strconv.Itoa(i),
+							},
+						},
+					}
+
+					harmonyClient.EXPECT().GetBlockByNumber(gomock.Any()).Return(block, nil)
+
+					bqClient.EXPECT().InsertBlock(gomock.Any(), block).Return(nil)
+					bqClient.EXPECT().InsertTransactions(gomock.Any(), block.Transactions).Return(nil)
+				}
+			},
+		},
+		{
+			name:         "skips filled blocks and txns",
+			currentCount: 1,
+			endBlock:     10,
+			setupMocks: func(harmonyClient *mock_harmony.MockHarmonyClient, bqClient *mock_bigquery.MockBigQueryClient) {
+				for i := 1; i <= 10; i++ {
+					var (
+						returnBlock *model.Block
+						returnTxns  []*model.Transaction
+					)
+
+					if i%2 == 0 {
+						returnBlock = &model.Block{
+							Number: strconv.Itoa(i),
+						}
+						returnTxns = []*model.Transaction{
+							{
+								BlockNumber: strconv.Itoa(i),
+							},
+						}
+					}
+
+					bqClient.EXPECT().GetBlock(gomock.Any(), int64(i)).Return(returnBlock, nil)
+					bqClient.EXPECT().GetTransactions(gomock.Any(), int64(i)).Return(returnTxns, nil)
+
+					block := &model.Block{
+						Number: strconv.Itoa(i),
+						Transactions: []*model.Transaction{
+							{
+								BlockNumber: strconv.Itoa(i),
+							},
+						},
+					}
+
+					harmonyClient.EXPECT().GetBlockByNumber(gomock.Any()).Return(block, nil)
+
+					if i%2 != 0 {
+						bqClient.EXPECT().InsertBlock(gomock.Any(), block).Return(nil)
+						bqClient.EXPECT().InsertTransactions(gomock.Any(), block.Transactions).Return(nil)
+					}
+				}
+			},
+		},
+		{
+			name:         "skips filled blocks but fills in missing txns",
+			currentCount: 1,
+			endBlock:     10,
+			setupMocks: func(harmonyClient *mock_harmony.MockHarmonyClient, bqClient *mock_bigquery.MockBigQueryClient) {
+				for i := 1; i <= 10; i++ {
+					var returnBlock *model.Block
+
+					if i == 5 {
+						returnBlock = &model.Block{
+							Number: strconv.Itoa(i),
+						}
+					}
+
+					bqClient.EXPECT().GetBlock(gomock.Any(), int64(i)).Return(returnBlock, nil)
+					bqClient.EXPECT().GetTransactions(gomock.Any(), int64(i)).Return(nil, nil)
+
+					block := &model.Block{
+						Number: strconv.Itoa(i),
+						Transactions: []*model.Transaction{
+							{
+								BlockNumber: strconv.Itoa(i),
+							},
+						},
+					}
+
+					harmonyClient.EXPECT().GetBlockByNumber(gomock.Any()).Return(block, nil)
+
+					if i != 5 {
+						bqClient.EXPECT().InsertBlock(gomock.Any(), block).Return(nil)
+					}
+					bqClient.EXPECT().InsertTransactions(gomock.Any(), block.Transactions).Return(nil)
+				}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			harmonyClient := mock_harmony.NewMockHarmonyClient(ctrl)
+			bqClient := mock_bigquery.NewMockBigQueryClient(ctrl)
+
+			runner := &BackfillRunner{
+				harmonyClient:  harmonyClient,
+				bigQueryClient: bqClient,
+				retryBlockChan: make(chan *model.RetryBlock),
+				retryTxnChan:   make(chan *model.RetryTransaction),
+				logger:         zap.NewNop(),
+			}
+
+			tc.setupMocks(harmonyClient, bqClient)
+
+			counter := &counter{
+				tc.currentCount,
+				&sync.Mutex{},
+			}
+
+			wg := &sync.WaitGroup{}
+			wg.Add(1)
+
+			runner.backfillBlocks(context.TODO(), counter, wg, 10)
+		})
+	}
+}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -7,7 +7,7 @@ import (
 var (
 	BlocksTableSchema = bigquery.Schema{
 		{Name: "blockHash", Type: bigquery.StringFieldType},
-		{Name: "difficulty", Type: bigquery.StringFieldType},
+		{Name: "difficulty", Type: bigquery.IntegerFieldType},
 		{Name: "epoch", Type: bigquery.StringFieldType},
 		{Name: "extraData", Type: bigquery.StringFieldType},
 		{Name: "gasLimit", Type: bigquery.StringFieldType},


### PR DESCRIPTION
Update to perform a check if a block and its transactions exist in BigQuery before attempting to insert them. If the block and its transactions are not found it will continue with an insert attempt. 